### PR TITLE
Add pyproject.toml and move metadata to setup.cfg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[metadata]
+name = bink
+version = 0.3.1
+author = Rafael Garcia
+description = Runtime for Ink, a scripting language for writing interactive narrative
+long_description = file: README.rst
+license = Apache 2.0
+classifiers =
+    Programming Language :: Python :: 3
+
+[options]
+zip_safe = False
+packages = find:
+
+[options.packages.find]
+exclude =
+    tests*
+    dist*
+    build*

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,20 @@
 """Package definition."""
-import setuptools, sys
-from setuptools import find_packages, setup
-from wheel.bdist_wheel import bdist_wheel
-from os import path
-from io import open
 
-class BinaryDistribution (setuptools.Distribution):
+
+import sys
+from setuptools import setup, Distribution
+from wheel.bdist_wheel import bdist_wheel
+
+
+class BinaryDistribution (Distribution):
     def has_ext_modules(self):
         return True
 
+
 class BdistWheel(bdist_wheel):
     def get_tag(self):
-        return ('py3', 'none') + bdist_wheel.get_tag(self)[2:]
+        return ('py3', 'none') + super().get_tag()[2:]
+
 
 def get_package_data():
     plat_name_idx = None
@@ -32,35 +35,23 @@ def get_package_data():
             lib = 'bink.dll'
         else:
             raise RuntimeError('Unsupported platform: ' + plat_name)
-        
+
         arch = "x86_64/"
         if "arm64" in plat_name or "aarch64" in plat_name:
             arch = "arm64/"
 
         lib = arch + lib
-        
+
         return ['native/' + lib]
 
     # if it is not present, return ['native/*']
     return ['native/*']
 
-description = open(
-    path.join(path.abspath(path.dirname(__file__)), 'README.rst'),
-    encoding='utf-8').read()
 
 setup(
-    name='bink',
-    packages=find_packages(exclude=['tests']),
-    version='0.3.1',
-    description='Runtime for Ink, a scripting language for writing interactive narrative',
-    long_description_content_type='text/x-rst',
-    long_description=description,
-    author='Rafael Garcia',
-    license='Apache 2.0',
     package_data={'bink': get_package_data()},
     distclass = BinaryDistribution,
     cmdclass = {
         'bdist_wheel': BdistWheel,
     },
-    zip_safe=False # native libraries are included in the package
 )


### PR DESCRIPTION
The pyproject.toml make the project buildable with pip without calling directly to setup.py.

The metadata in setup.cfg makes the setup.py smaller and it's easier to modify metadata in the cfg file instead of using python directly.