### PR TITLE
Fix choices index bounds

### DIFF
--- a/bink/choices.py
+++ b/bink/choices.py
@@ -40,7 +40,13 @@ class Choices:
         if not isinstance(idx, int):
             raise TypeError
 
-        if idx < 0 or idx > self._len:
+        # The index is 0-based; valid values range from 0 to ``self._len - 1``.
+        # The previous check allowed ``idx == self._len`` which would defer the
+        # bounds validation to the underlying C library, resulting in a
+        # ``RuntimeError`` instead of the expected ``IndexError``. Ensure the
+        # upper bound is exclusive so out-of-range access raises ``IndexError``
+        # consistently.
+        if idx < 0 or idx >= self._len:
             raise IndexError
 
         return self.get_text(idx)

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -1,0 +1,12 @@
+import pytest
+from bink.story import story_from_file
+
+
+def test_choices_getitem_out_of_bounds():
+    story = story_from_file("inkfiles/TheIntercept.ink.json")
+    # Advance the story until at least one choice is available
+    while story.can_continue() and len(story.choices) == 0:
+        story.cont()
+    choices = story.choices
+    with pytest.raises(IndexError):
+        _ = choices[len(choices)]


### PR DESCRIPTION
## Summary
- Ensure `Choices.__getitem__` rejects indices equal to the length to raise `IndexError`
- Add regression test for out-of-bounds access on choices

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68af2b57289083338e7381867c3e6680